### PR TITLE
renamed pkg errgroupn to errgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# errgroupn
-`errgroupn` is a drop-in alternative to Go's wonderful [`sync/errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup) but limited
-to `N` goroutines. This is useful for interaction with rate-limited
+# neilotoole/errgroup
+`neilotoole/errgroup` is a drop-in alternative to Go's wonderful
+[`sync/errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup) but
+limited to `N` goroutines. This is useful for interaction with rate-limited
 APIs, databases, and the like.
 
 ## Overview
-In effect, `errgroupn` is `errgroup` but with a worker pool
+In effect, `neilotoole/errgroup` is `sync/errgroup` but with a worker pool
 of `N` goroutines. The exported API is identical but for an additional
 function `WithContextN`, which allows the caller
 to specify the maximum number of goroutines (`numG`) and the capacity
@@ -27,22 +28,14 @@ to
 
 ```go
 import (
-  "github.com/neilotoole/errgroupn"
-)
-```
-
-or for a clean drop-in replacement of `sync/errgroup`:
-
-```go
-import (
-  "errgroup" "github.com/neilotoole/errgroupn"
+  "github.com/neilotoole/errgroup"
 )
 ```
 
 Then use in the normal manner.
 
 ```go
-g, ctx := errgroupn.WithContext(ctx)
+g, ctx := errgroup.WithContext(ctx)
 g.Go(func() error {
     // do something
     return nil
@@ -58,23 +51,23 @@ For that you'll need `WithContextN`:
 
 ```go
 numG, qSize := 8, 4
-g, ctx := errgroupn.WithContextN(ctx, numG, qSize)
+g, ctx := errgroup.WithContextN(ctx, numG, qSize)
 
 ```
 
 ## Performance
-The motivation for creating `errgroupn` was to provide rate-limiting while
+The motivation for creating `neilotoole/errgroup` was to provide rate-limiting while
 maintaining the lovely `sync/errgroup` semantics. Sacrificing some
 performance vs `sync/errgroup` was assumed. However, benchmarking
-suggests that `errgroupn` can be more effective than `sync/errgroup` 
+suggests that implementation can be more effective than `sync/errgroup` 
 when tuned for a specific workload.
 
 Below is a selection of benchmark results. How to read this: a workload is _X_ tasks
 of _Y_ complexity. The workload is executed for:
  
-- `sync/errgroup`
+- `sync/errgroup`, listed as `sync_errgroup`
 - a non-parallel implementation (`sequential`)
-- various `{numG, qSize}` configurations of `errgroupn`
+- various `{numG, qSize}` configurations of `neilotoole/errgroup`, listed as `errgroupn`
 
 ```
 BenchmarkGroup_Short/complexity_5/tasks_50/errgroupn_default_16_16-16         	   25574	     46867 ns/op	     688 B/op	      12 allocs/op
@@ -99,7 +92,7 @@ BenchmarkGroup_Short/complexity_40/tasks_250/sync_errgroup-16                 	 
 BenchmarkGroup_Short/complexity_40/tasks_250/sequential-16                    	     200	   5924693 ns/op	       0 B/op	       0 allocs/op
 ```
 
-The overall impression is that that `errgroupn` can provide higher
+The overall impression is that that `neilotoole/errgroup` can provide higher
 throughput than `sync/errgroup` for these (CPU-intensive) workloads,
 sometimes significantly so. As always, these benchmark results should
 not be taken as gospel: your results may vary.
@@ -111,8 +104,8 @@ Why require an explicit `qSize` limit?
 If the number of calls to `Group.Go` results in `qCh` becoming
 full, the `Go` method will block until worker goroutines relieve `qCh`.
 This behavior is in contrast to `sync/errgroup`'s `Go` method, which doesn't block.
-While `errgroupn` aims to be as much of a behaviorally identical
-"drop-in" alternative to `errgroup` as possible, this blocking behavior
+While `neilotoole/errgroup` aims to be as much of a behaviorally similar
+"drop-in" alternative to `sync/errgroup` as possible, this blocking behavior
 is an accepted deviation.
 
 Noting that the capacity of `qCh` is controlled by `qSize`, it's probable an
@@ -121,8 +114,8 @@ acting - if `qCh` is full - as a buffer for functions passed to `Go`.
 Consideration of this potential design led to this [issue](https://github.com/golang/go/issues/20352)
 regarding _unlimited capacity channels_, or perhaps better characterized
 in this particular case as "_growable capacity channels_". If such a
-feature existed in the language, it's possible that `errgroupn` might
-have taken advantage of it, at least in the first-pass release (benchmarking
-etc notwithstanding). However benchmarking seems to suggest that a relatively
+feature existed in the language, it's possible that this implementation might
+have taken advantage of it, at least in the first-pass release (benchmarking notwithstanding).
+However benchmarking seems to suggest that a relatively
 small `qSize` has performance benefits for some workloads, so it's possible
 that the explicit `qSize` requirement is a better design choice.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,4 +1,4 @@
-package errgroupn_test
+package errgroup_test
 
 import (
 	"context"
@@ -9,10 +9,10 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/neilotoole/errgroupn"
+	errgroupn "github.com/neilotoole/errgroup"
 )
 
-// BenchmarkGroup_Short is a (shorter) benchmark of errgroupn.
+// BenchmarkGroup_Short is a (shorter) benchmark of errgroup.
 //
 //   go test -run=XXX -bench=BenchmarkGroup_Short -benchtime=1s
 func BenchmarkGroup_Short(b *testing.B) {

--- a/errgroup.go
+++ b/errgroup.go
@@ -1,4 +1,4 @@
-// Package errgroupn is an extension of the sync/errgroup
+// Package neilotoole/errgroup is an extension of the sync/errgroup
 // concept, and much of the code herein is descended from
 // or directly copied from that sync/errgroup code which
 // has this header comment:
@@ -7,10 +7,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package errgroupn is a drop-in alternative to errgroup but
-// limited to N goroutines. In effect, errgroupn is errgroup
-// but with a worker pool of N goroutines.
-package errgroupn
+// Package errgroup is a drop-in alternative to sync/errgroup but
+// limited to N goroutines. In effect, neilotoole/errgroup is
+// sync/errgroup but with a worker pool of N goroutines.
+package errgroup
 
 import (
 	"context"

--- a/errgroup_example_md5all_test.go
+++ b/errgroup_example_md5all_test.go
@@ -3,11 +3,12 @@
 // license that can be found in the LICENSE file.
 
 // Note: This file is copied directly from errgroup/errgroup_example_md5all_test.go
-// with the one-line change that pkg neilotoole/errgroupn is imported
-// as errgroup. This was done to test if neilotoole/errgroupn can be
-// characterized as a "drop-in" replacement for sync/errgroup.
+// with the one-line change that pkg neilotoole/errgroup is imported
+// as errgroup. The purpose is to test if neilotoole/errgroup can be
+// characterized as a "drop-in" replacement for sync/errgroup, by
+// seamlessly passing all of sync/errgroup's tests.
 
-package errgroupn_test
+package errgroup_test
 
 import (
 	"context"
@@ -18,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
-	errgroup "github.com/neilotoole/errgroupn"
+	"github.com/neilotoole/errgroup"
 )
 
 // Pipeline demonstrates the use of a Group to implement a multi-stage

--- a/errgroup_test.go
+++ b/errgroup_test.go
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// This file is copied directly from errgroup/errgroup_test.go with
-// the one-line change that pkg neilotoole/errgroupn is imported
-// as errgroup. This was done to test if neilotoole/errgroupn can be
-// characterized as a "drop-in" replacement for sync/errgroup.
+// Note: This file is copied directly from errgroup/errgroup_example_md5all_test.go
+// with the one-line change that pkg neilotoole/errgroup is imported
+// instead of sync/errgroup. The purpose is to test if neilotoole/errgroup
+// can be characterized as a "drop-in" replacement for sync/errgroup, by
+// seamlessly passing all of sync/errgroup's tests.
 
-package errgroupn_test
+package errgroup_test
 
 import (
 	"context"
@@ -17,7 +18,7 @@ import (
 	"os"
 	"testing"
 
-	errgroup "github.com/neilotoole/errgroupn"
+	"github.com/neilotoole/errgroup"
 )
 
 var (

--- a/errgroupn_test.go
+++ b/errgroupn_test.go
@@ -1,4 +1,4 @@
-package errgroupn_test
+package errgroup_test
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/neilotoole/errgroupn"
+	errgroupn "github.com/neilotoole/errgroup"
 )
 
 // grouper is an abstraction of errgroup.Group's exported methodset.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/neilotoole/errgroupn
+module github.com/neilotoole/errgroup
 
 go 1.14
 


### PR DESCRIPTION
To make it easier to use this impl as a drop-in alternative to `sync/errgroup`, the package has been renamed to `neilotoole/errgroup`.