### PR TITLE
fix: spawn worker when one die

### DIFF
--- a/errgroup.go
+++ b/errgroup.go
@@ -190,6 +190,7 @@ func (g *Group) startG() {
 	g.wg.Add(1)
 	go func() {
 		defer g.wg.Done()
+		defer atomic.AddInt64(&g.gCount, -1)
 
 		var f func() error
 


### PR DESCRIPTION
If a worker die, it doen't update gCount so maybeStartG doesn't start a
new one.