### PR TITLE
fix: continue loop when f return error

### DIFF
--- a/errgroup.go
+++ b/errgroup.go
@@ -211,8 +211,6 @@ func (g *Group) startG() {
 						g.cancel()
 					}
 				})
-
-				return
 			}
 		}
 	}()


### PR DESCRIPTION
If f return error, the worker will die. Under some conditions, all f enqueue qCh but all worker dead, qCh's reset f will not be excuted.