### PR TITLE
fix: Fix deadlock raised in #11

### DIFF
--- a/errgroup.go
+++ b/errgroup.go
@@ -173,10 +173,8 @@ func (g *Group) Go(f func() error) {
 
 			return
 		default:
-			break
+			g.errMu.RUnlock()
 		}
-
-		g.errMu.RUnlock()
 	}
 }
 


### PR DESCRIPTION
This fixes #11 .

Root cause: 
- When an error occurs we exit a worker by returning from `startG` function.
- If the number of workers `gCount` reaches 0 while all other functions are already in the buffer then a deadlock will be reached since there is no chance a new worker will be created and the current number of workers is 0.

Fix: (Note: there are different ways of achieving this)
- Before adding to the buffer check if there was already an error, in case there was then just exit and don't try to add to buffer.
- Unit test added